### PR TITLE
Add some Native resource obj

### DIFF
--- a/src/ubuntumirclient/nativeinterface.cpp
+++ b/src/ubuntumirclient/nativeinterface.cpp
@@ -67,9 +67,12 @@ void* UbuntuNativeInterface::nativeResourceForIntegration(const QByteArray &reso
 
     const ResourceType resourceType = ubuntuResourceMap()->value(lowerCaseResource);
 
-    if (resourceType == UbuntuNativeInterface::MirConnection) {
+    switch (resourceType) {
+    case EglDisplay:
+        return mIntegration->eglDisplay();
+    case MirConnection:
         return mIntegration->mirConnection();
-    } else {
+    default:
         return nullptr;
     }
 }

--- a/src/ubuntumirclient/nativeinterface.cpp
+++ b/src/ubuntumirclient/nativeinterface.cpp
@@ -33,6 +33,7 @@ public:
         : QMap<QByteArray, UbuntuNativeInterface::ResourceType>() {
         insert("egldisplay", UbuntuNativeInterface::EglDisplay);
         insert("eglcontext", UbuntuNativeInterface::EglContext);
+        insert("eglconfig", UbuntuNativeInterface::EglConfig);
         insert("nativeorientation", UbuntuNativeInterface::NativeOrientation);
         insert("display", UbuntuNativeInterface::Display);
         insert("mirconnection", UbuntuNativeInterface::MirConnection);
@@ -90,10 +91,14 @@ void* UbuntuNativeInterface::nativeResourceForContext(
 
     const ResourceType kResourceType = ubuntuResourceMap()->value(kLowerCaseResource);
 
-    if (kResourceType == UbuntuNativeInterface::EglContext)
+    switch (kResourceType) {
+    case EglConfig:
+        return static_cast<UbuntuOpenGLContext*>(context->handle())->eglConfig();
+    case EglContext:
         return static_cast<UbuntuOpenGLContext*>(context->handle())->eglContext();
-    else
+    default:
         return nullptr;
+    }
 }
 
 void* UbuntuNativeInterface::nativeResourceForWindow(const QByteArray& resourceString, QWindow* window)

--- a/src/ubuntumirclient/nativeinterface.h
+++ b/src/ubuntumirclient/nativeinterface.h
@@ -26,7 +26,7 @@ class QPlatformScreen;
 class UbuntuNativeInterface : public QPlatformNativeInterface {
     Q_OBJECT
 public:
-    enum ResourceType { EglDisplay, EglContext, NativeOrientation, Display, MirConnection, MirSurface, Scale, FormFactor };
+    enum ResourceType { EglDisplay, EglContext, NativeOrientation, Display, MirConnection, MirSurface, Scale, FormFactor, EglConfig };
 
     UbuntuNativeInterface(const UbuntuClientIntegration *integration);
     ~UbuntuNativeInterface();


### PR DESCRIPTION
This adds lets nativeResourceForContext return EglConfig and let nativeResourceForIntegration return EglDisplay to match how qt expect it to be.

This is needed for QtWebEngine to support native GPU.