### PR TITLE
Return EglDisplay from pni->nativeResourceForIntegration()

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+qtubuntu (0.65.1+ubports) xenial; urgency=medium
+
+  * Return EglDisplay from pni->nativeResourceForIntegration()
+
+ -- Ratchanan Srirattanamet <peathot@hotmail.com>  Sat, 14 Sep 2019 00:34:45 +0700
+
 qtubuntu (0.64.1+ubports) xenial; urgency=medium
 
   * Imported to UBports

--- a/src/ubuntumirclient/qmirclientnativeinterface.cpp
+++ b/src/ubuntumirclient/qmirclientnativeinterface.cpp
@@ -91,9 +91,12 @@ void* QMirClientNativeInterface::nativeResourceForIntegration(const QByteArray &
 
     const ResourceType resourceType = ubuntuResourceMap()->value(lowerCaseResource);
 
-    if (resourceType == QMirClientNativeInterface::MirConnection) {
+    switch (resourceType) {
+    case EglDisplay:
+        return mIntegration->eglDisplay();
+    case MirConnection:
         return mIntegration->mirConnection();
-    } else {
+    default:
         return nullptr;
     }
 }


### PR DESCRIPTION
EglDisplay doesn't seem to change between different window, so it should
be safe to also return it from nativeResourceForIntegration().

This is required (or at least highly recommended) by
nemo-qtmultimedia-plugins.