### PR TITLE
[QMirScreen] Don't send orientation events before initial buffers

### DIFF
--- a/src/ubuntumirclient/qmirclientscreen.h
+++ b/src/ubuntumirclient/qmirclientscreen.h
@@ -79,6 +79,7 @@ public:
     void updateMirOutput(const MirOutput *output);
     void setAdditionalMirDisplayProperties(float scale, MirFormFactor formFactor, int dpi);
     void handleWindowSurfaceResize(int width, int height);
+    void onInitialBuffer();
 
     // QObject methods.
     void customEvent(QEvent* event) override;
@@ -86,6 +87,7 @@ public:
 private:
     void setMirOutput(const MirOutput *output);
     void updateLogicalDpi();
+    void handleScreenOrientationChange();
 
     QRect mGeometry, mNativeGeometry;
     QSizeF mPhysicalSize;
@@ -101,6 +103,8 @@ private:
     QMirClientCursor mCursor;
     float mLogicalDpiEnv{0};
     QDpi mLogicalDpi;
+    bool mCurrentOrientationDirty = false;
+    bool mReceivedInitialBuffer = false;
 
     static const float mMirScaleToLogicalDpiMultiplier;
 

--- a/src/ubuntumirclient/qmirclientwindow.cpp
+++ b/src/ubuntumirclient/qmirclientwindow.cpp
@@ -1022,6 +1022,11 @@ void QMirClientWindow::onSwapBuffersDone()
     QMutexLocker lock(&mMutex);
     mSurface->onSwapBuffersDone();
 
+    if (!mReceivedInitialBuffer) {
+        mReceivedInitialBuffer = true;
+        static_cast<QMirClientScreen*>(screen())->onInitialBuffer();
+    }
+
     if (mSurface->mNeedsExposeCatchup) {
         mSurface->mNeedsExposeCatchup = false;
         mWindowExposed = false;

--- a/src/ubuntumirclient/qmirclientwindow.h
+++ b/src/ubuntumirclient/qmirclientwindow.h
@@ -115,6 +115,7 @@ private:
     std::unique_ptr<UbuntuSurface> mSurface;
     float mScale;
     MirFormFactor mFormFactor;
+    bool mReceivedInitialBuffer = false;
 };
 
 #endif // QMIRCLIENTWINDOW_H


### PR DESCRIPTION
We should not send orientation events before we have got the initial
buffers, as qt will segfault with some clients if a orientation event is
called before it got a buffer to draw.

This fixes: https://github.com/ubports/ubuntu-touch/issues/1241