### PR TITLE
Fix inconsistent application state

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
+
 pipeline {
   agent any
   stages {
     stage('Build source') {
       steps {
         sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        stash(name: 'source', includes: stashFileList)
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
@@ -17,7 +20,7 @@ pipeline {
               unstash 'source'
               sh '''export architecture="armhf"
 build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              stash(includes: stashFileList, name: 'build-armhf')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
 
@@ -29,7 +32,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="arm64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              stash(includes: stashFileList, name: 'build-arm64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           },
@@ -39,7 +42,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="amd64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              stash(includes: stashFileList, name: 'build-amd64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           }
@@ -52,7 +55,7 @@ build-binary.sh'''
         unstash 'build-armhf'
         unstash 'build-arm64'
         unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }
     }

--- a/src/ubuntumirclient/qmirclientappstatecontroller.cpp
+++ b/src/ubuntumirclient/qmirclientappstatecontroller.cpp
@@ -50,7 +50,8 @@
  */
 
 QMirClientAppStateController::QMirClientAppStateController()
-    : m_suspended(false)
+    : QObject()
+    , m_suspended(false)
     , m_lastActive(true)
 {
     m_inactiveTimer.setSingleShot(true);

--- a/src/ubuntumirclient/qmirclientappstatecontroller.cpp
+++ b/src/ubuntumirclient/qmirclientappstatecontroller.cpp
@@ -52,7 +52,7 @@
 QMirClientAppStateController::QMirClientAppStateController()
     : QObject()
     , m_suspended(false)
-    , m_lastActive(true)
+    , m_focused(true)
 {
     m_inactiveTimer.setSingleShot(true);
     m_inactiveTimer.setInterval(10);
@@ -78,7 +78,7 @@ void QMirClientAppStateController::setResumed()
     if (m_suspended) {
         m_suspended = false;
 
-        if (m_lastActive) {
+        if (m_focused) {
             QWindowSystemInterface::handleApplicationStateChanged(Qt::ApplicationActive);
         } else {
             QWindowSystemInterface::handleApplicationStateChanged(Qt::ApplicationInactive);
@@ -88,6 +88,11 @@ void QMirClientAppStateController::setResumed()
 
 void QMirClientAppStateController::setWindowFocused(bool focused)
 {
+    // A window can be focused before the app is resumed because lifecycle state
+    // in Unity8 is a function of focused state. However, application state
+    // should stay at suspended in that case.
+    m_focused = focused;
+
     if (m_suspended) {
         return;
     }
@@ -98,6 +103,4 @@ void QMirClientAppStateController::setWindowFocused(bool focused)
     } else {
         m_inactiveTimer.start();
     }
-
-    m_lastActive = focused;
 }

--- a/src/ubuntumirclient/qmirclientappstatecontroller.h
+++ b/src/ubuntumirclient/qmirclientappstatecontroller.h
@@ -59,7 +59,7 @@ public Q_SLOTS:
 
 private:
     bool m_suspended;
-    bool m_lastActive;
+    bool m_focused;
     QTimer m_inactiveTimer;
 };
 

--- a/src/ubuntumirclient/qmirclientappstatecontroller.h
+++ b/src/ubuntumirclient/qmirclientappstatecontroller.h
@@ -41,17 +41,21 @@
 #ifndef QMIRCLIENTAPPSTATECONTROLLER_H
 #define QMIRCLIENTAPPSTATECONTROLLER_H
 
+#include <QObject>
 #include <QTimer>
 
-class QMirClientAppStateController
+class QMirClientAppStateController : public QObject
 {
+    Q_OBJECT
+
 public:
     QMirClientAppStateController();
 
+    void setWindowFocused(bool focused);
+
+public Q_SLOTS:
     void setSuspended();
     void setResumed();
-
-    void setWindowFocused(bool focused);
 
 private:
     bool m_suspended;

--- a/src/ubuntumirclient/qmirclientintegration.cpp
+++ b/src/ubuntumirclient/qmirclientintegration.cpp
@@ -74,7 +74,11 @@
 static void resumedCallback(const UApplicationOptions */*options*/, void *context)
 {
     auto integration = static_cast<QMirClientClientIntegration*>(context);
-    integration->appStateController()->setResumed();
+
+    // Make sure calls to appStateController happen on the main thread.
+    QMetaObject::invokeMethod(integration->appStateController(),
+                                "setResumed",
+                                Qt::QueuedConnection);
 }
 
 static void aboutToStopCallback(UApplicationArchive */*archive*/, void *context)
@@ -86,7 +90,11 @@ static void aboutToStopCallback(UApplicationArchive */*archive*/, void *context)
     } else {
         qCWarning(mirclient) << "aboutToStopCallback(): no input context";
     }
-    integration->appStateController()->setSuspended();
+
+    // Make sure calls to appStateController happen on the main thread.
+    QMetaObject::invokeMethod(integration->appStateController(),
+                                "setSuspended",
+                                Qt::QueuedConnection);
 }
 
 


### PR DESCRIPTION
This PR contains 3 commits. The first one updates Jenkinsfile to the latest version.

The second one fixes the race condition in appStateController's set{Suspended,Resumed}. The appStateController is converted to a QObject, and the callback is changed to invoke these method using QueuedConnection.

The third one make sure that whether the focused signal arrived before or after resumed signal, the application state will still be correct. It does that by saving the focused state regardless of current suspend state.

Together, this fixes intermittent application state. I can't find a bug report on this, but @Flohack74 has mentioned it in https://github.com/ubports/qtubuntu-sensors/pull/3#issuecomment-566708650. @Flohack74, interested in trying this out?