### PR TITLE
Add Native Interface EglConfig

### DIFF
--- a/src/ubuntumirclient/qmirclientnativeinterface.cpp
+++ b/src/ubuntumirclient/qmirclientnativeinterface.cpp
@@ -57,6 +57,7 @@ public:
         : QMap<QByteArray, QMirClientNativeInterface::ResourceType>() {
         insert("egldisplay", QMirClientNativeInterface::EglDisplay);
         insert("eglcontext", QMirClientNativeInterface::EglContext);
+        insert("eglconfig", QMirClientNativeInterface::EglConfig);
         insert("nativeorientation", QMirClientNativeInterface::NativeOrientation);
         insert("display", QMirClientNativeInterface::Display);
         insert("mirconnection", QMirClientNativeInterface::MirConnection);
@@ -114,10 +115,14 @@ void* QMirClientNativeInterface::nativeResourceForContext(
 
     const ResourceType kResourceType = ubuntuResourceMap()->value(kLowerCaseResource);
 
-    if (kResourceType == QMirClientNativeInterface::EglContext)
+    switch (kResourceType) {
+    case EglConfig:
+        return static_cast<QMirClientOpenGLContext*>(context->handle())->eglConfig();
+    case EglContext:
         return static_cast<QMirClientOpenGLContext*>(context->handle())->eglContext();
-    else
+    default:
         return nullptr;
+    }
 }
 
 void* QMirClientNativeInterface::nativeResourceForWindow(const QByteArray& resourceString, QWindow* window)

--- a/src/ubuntumirclient/qmirclientnativeinterface.h
+++ b/src/ubuntumirclient/qmirclientnativeinterface.h
@@ -50,7 +50,7 @@ class QPlatformScreen;
 class QMirClientNativeInterface : public QPlatformNativeInterface {
     Q_OBJECT
 public:
-    enum ResourceType { EglDisplay, EglContext, NativeOrientation, Display, MirConnection, MirWindow, Scale, FormFactor };
+    enum ResourceType { EglDisplay, EglContext, NativeOrientation, Display, MirConnection, MirWindow, Scale, FormFactor, EglConfig };
 
     QMirClientNativeInterface(const QMirClientClientIntegration *integration);
     ~QMirClientNativeInterface();


### PR DESCRIPTION
This is based on work done by @balcy, i only rebased and put it into a single commit. 

This seems to work now with qt 5.12 where the api seems to be able to eglGetProcAddress from qt platfroms, this allows us to enable gpu acceleration on hybris devices. 

![image](https://user-images.githubusercontent.com/1642635/107775348-71d43800-6d40-11eb-96b5-4a3eb0d0d6b1.png)

This fixes: https://gitlab.com/ubports/core/packaging/qtwebengine/-/issues/1
