### PR TITLE
Use RasterGLSurface instead.

### DIFF
--- a/src/ubuntumirclient/qmirclientbackingstore.cpp
+++ b/src/ubuntumirclient/qmirclientbackingstore.cpp
@@ -57,7 +57,7 @@ QMirClientBackingStore::QMirClientBackingStore(QWindow* window)
     mContext->setScreen(window->screen());
     mContext->create();
 
-    window->setSurfaceType(QSurface::OpenGLSurface);
+    window->setSurfaceType(QSurface::RasterGLSurface);
 }
 
 QMirClientBackingStore::~QMirClientBackingStore()


### PR DESCRIPTION
With newer versions of Qt, QWidgets apps are getting a blank/transparent
window rather than drawing properly. Change to use the RasterGLSurface type
instead seems to fix this.