### PR TITLE
platformtheme: Implement DoubleClick/DoubleTap distances

### DIFF
--- a/src/shared/ubuntutheme.h
+++ b/src/shared/ubuntutheme.h
@@ -16,6 +16,8 @@
 
 #include <QVariant>
 #include <QtThemeSupport/private/qgenericunixthemes_p.h>
+#include <QGuiApplication>
+#include <QScreen>
 
 class UbuntuTheme : public QGenericUnixTheme
 {
@@ -39,6 +41,22 @@ public:
             } else {
                 return iconTheme;
             }
+        }
+        case QPlatformTheme::MouseDoubleClickDistance: {
+            // Impl mostly yoinked from the QAndroidPlatformTheme
+            QScreen *screen = qGuiApp->primaryScreen();
+            if (screen) {
+                qreal dotsPerInch = screen->physicalDotsPerInch();
+                // Allow 15% of an inch between taps when double clicking
+                return qRound(dotsPerInch * 0.15);
+            } else {
+                return 5;
+            }
+        }
+        case QPlatformTheme::TouchDoubleTapDistance: {
+            bool ok = false;
+            int dist = themeHint(QPlatformTheme::MouseDoubleClickDistance).toInt(&ok) * 2;
+            return QVariant(ok ? dist : 10);
         }
         default:
             break;


### PR DESCRIPTION
In Qt 5.12.4[1], Qt started checking for the distance between two clicks or taps when deciding whether a Clicked event should become a DoubleClicked event. The default distance in Qt 5.12.9 is 5 pixels horizontally or vertically from the initial click point. The double tap distance is defined as twice the double click distance[2].

We can use the DPI value of the screen to determine a likely value of .15 (3/20) of an inch for distance between click events, and .30 of an inch for touch events. These values, and most of the implementation, were taken from the Android QPA[3].

Fixes https://github.com/ubports/keyboard-component/issues/159
Fixes https://github.com/ubports/keyboard-component/issues/158

[1] https://github.com/qt/qtdeclarative/commit/56fbc277a1acc49d9ead4c89edd250a021ef2a01
[2] https://github.com/qt/qtbase/blob/5.12.9/src/gui/kernel/qplatformtheme.cpp#L548-L563
[3]https://github.com/qt/qtbase/blob/v5.12.9/src/plugins/platforms/android/qandroidplatformtheme.cpp#L469